### PR TITLE
Add _artists_{album,track}_all_sort_multi tags

### DIFF
--- a/plugins/additional_artists_variables/__init__.py
+++ b/plugins/additional_artists_variables/__init__.py
@@ -205,6 +205,8 @@ def process_artists(album_id, source_metadata, destination_metadata, source_type
         destination_metadata['~artists_{0}_all_std_multi'.format(source_type,)] = std_artist_list
     if cred_artist_list:
         destination_metadata['~artists_{0}_all_cred_multi'.format(source_type,)] = cred_artist_list
+    if sort_artist_list:
+        destination_metadata['~artists_{0}_all_sort_multi'.format(source_type,)] = sort_artist_list
     if legal_artist_list:
         destination_metadata['~artists_{0}_all_legal_multi'.format(source_type,)] = legal_artist_list
     if sort_pri_artist:

--- a/plugins/additional_artists_variables/docs/README.md
+++ b/plugins/additional_artists_variables/docs/README.md
@@ -43,6 +43,7 @@ variables provided by this plugin.
 * **_artists_album_all_legal** - All album artists listed (legal names), separated by strings provided from the release entry
 * **_artists_album_all_std_multi** - All album artists listed (standardized), as a multi-value
 * **_artists_album_all_cred_multi** - All album artists listed (as credited), as a multi-value
+* **_artists_album_all_sort_multi** - All album artists listed (sort names), as a multi-value
 * **_artists_album_all_legal_multi** - All album artists listed (legal names), as a multi-value
 * **_artists_album_all_sort_primary** - The primary / first album artist listed (sort name) followed by all additional album artists (standardized), separated by strings provided from the release entry
 * **_artists_album_all_types** - All album artist types, as a multi-value
@@ -72,6 +73,7 @@ variables provided by this plugin.
 * **_artists_track_all_legal** - All track artists listed (legal names), separated by strings provided from the track entry
 * **_artists_track_all_std_multi** - All track artists listed (standardized), as a multi-value
 * **_artists_track_all_cred_multi** - All track artists listed (as credited), as a multi-value
+* **_artists_track_all_sort_multi** - All track artists listed (sort names), as a multi-value
 * **_artists_track_all_legal_multi** - All track artists listed (legal names), as a multi-value
 * **_artists_track_all_sort_primary** - The primary / first track artist listed (sort name) followed by all additional track artists (standardized), separated by strings provided from the track entry
 * **_artists_track_all_types** - All track artist types, as a multi-value


### PR DESCRIPTION
The user guide of the additional artist variables plugin sent me to this fork, I hope this is the correct place to open a pull request.

It seems to have been an oversight that the `_all_sort_multi` tags were missing, `_artists_album_all_sort` and `_artists_album_additional_sort_multi` did exist already, the data was already there too.

I confirmed locally that the correct data is now exposed.