### PR TITLE
Fix TypeError when label data is None

### DIFF
--- a/plugins/label_variables/__init__.py
+++ b/plugins/label_variables/__init__.py
@@ -55,7 +55,7 @@ def process_labels(album_id, source_metadata, destination_metadata):
             if 'catalog-number' in label_info and label_info['catalog-number']:
                 catalog_number_count += 1
                 catalog_number_list.append(label_info['catalog-number'])
-            if 'label' in label_info:
+            if 'label' in label_info and label_info['label']:
                 label_count += 1
                 label_data = label_info['label']
                 label_id_list.append(label_data['id'] if 'id' in label_data and label_data['id'] else 'Unknown-Label-ID')


### PR DESCRIPTION
Some releases have a catalog number but no associated label, resulting in the 'label' field being None (null). This caused a "TypeError: argument of type 'NoneType' is not iterable" because the code only checked for the existence of the key, not the validity of the value.

Added a check to ensure label_info['label'] is truthy before processing.